### PR TITLE
short test installation

### DIFF
--- a/lectures/installation.rst
+++ b/lectures/installation.rst
@@ -74,3 +74,10 @@ Now you can launch a jupyterlab instance by clicking on **JupyterLab**.
 If your jupyterlab instance says something like "X needs to be added to
 the build", just click **Build**.
 
+
+Testing your installation
+=========================
+
+This workshop requires that you are familiar with Jupyter notebooks and how to run them. In the git repository that you have downloaded for the installation, you will find a notebook called `download_datasets.ipynb`. Open it and run it. This will download 6 datasets into the subfolder `data/`. You can try loading some of these datasets to make sure the download went through. Next, open the notebook for the first exercise, you will find it under `X_exercises/ch1-X-ex1.ipynb` (replace `X` with `python` or `r`). Make sure you are able to fully run the notebook. In case of installation issues, join us in the pre-workshop meeting (you have received details via email).
+
+


### PR DESCRIPTION
added a short paragraph on data download and test for installation so that people won't get stuck on the first day with issues with these two toolbox.

It could be improved by having a notebook or script that tests for all modules/libraries/functions needed during the days of the workshop, but we can iterate to better versions later.